### PR TITLE
Fix semver.org URL link

### DIFF
--- a/hcert_spec.md
+++ b/hcert_spec.md
@@ -9,7 +9,7 @@ This document specifies a generic data structure and encoding mechanisms for ele
 
 ### Versioning Policy
 
-Versions of this specification follow [semantic versioning](semver.org) and consist of three different integers describing the _major_, _minor_ and _edition_ version. A change in the _major_ version is an update that includes material changes affecting the decoding of the HCERT or the validation of it. An update of the _minor_ version is a feature or maintenance update that maintains backward compatibility with previous versions.
+Versions of this specification follow [semantic versioning](https://semver.org) and consist of three different integers describing the _major_, _minor_ and _edition_ version. A change in the _major_ version is an update that includes material changes affecting the decoding of the HCERT or the validation of it. An update of the _minor_ version is a feature or maintenance update that maintains backward compatibility with previous versions.
 
 In addition, there is an _edition_ version number used for publishing updates to the document itself which has no effect on the HCERT, such as correcting spelling, providing clarifications or addressing ambiguities, et cetera. Hence, the edition number is not indicated in the HCERT. The version numbers are expressed in the title page of the document using a _major.minor.edition_ format, where the three parts are separated by decimal dots.
 


### PR DESCRIPTION
Without the schema the rendered URL is relative to the document.